### PR TITLE
Use Dir instead of git

### DIFF
--- a/logstash-input-acquia.gemspec
+++ b/logstash-input-acquia.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.email            = 'sysadmin@equiem.com.au'
   s.homepage         = 'http://www.elastic.co/guide/en/logstash/current/index.html'
 
-  s.files         = `git ls-files -z`.split("\x0")
+  s.files         = Dir['Gemfile', 'Rakefile', 'lib/logstash/inputs/acquia.rb', 'logstash-input-acquia.gemspec', '.ruby-version']
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.test_files    = s.files.grep(%r{^spec/})
   s.require_paths = ['lib']

--- a/logstash-input-acquia.gemspec
+++ b/logstash-input-acquia.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.email            = 'sysadmin@equiem.com.au'
   s.homepage         = 'http://www.elastic.co/guide/en/logstash/current/index.html'
 
-  s.files         = Dir['Gemfile', 'Rakefile', 'lib/logstash/inputs/acquia.rb', 'logstash-input-acquia.gemspec', '.ruby-version']
+  s.files         = Dir['Gemfile', 'Rakefile', 'lib/logstash/inputs/acquia.rb', 'logstash-input-acquia.gemspec', '.ruby-version', 'VERSION', 'LICENSE']
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.test_files    = s.files.grep(%r{^spec/})
   s.require_paths = ['lib']


### PR DESCRIPTION
I'm using this plugin in a Docker container without GIT so the build fails because the git executable isn't available. We can use Dir instead.

Thanks